### PR TITLE
Added constraint on PropNotify<T>, T must implement IEquatable<T>.

### DIFF
--- a/PropNotify/Example/Invoice.cs
+++ b/PropNotify/Example/Invoice.cs
@@ -1,31 +1,16 @@
-﻿namespace Example
+﻿using System;
+
+namespace Example
 {
-    public class Invoice
+    public class Invoice : IEquatable<Invoice>
     {
         public long Id { get; set; }
         public double Payment { get; set; }
         public bool Cancelled { get; set; }
-
-        public override bool Equals(object obj)
-        {
-            var pCast = (Invoice)obj;
-            return Id.Equals(pCast.Id);
-        }
-
-        protected bool Equals(Invoice other)
+        
+        public bool Equals(Invoice other)
         {
             return Id == other.Id && Payment.Equals(other.Payment) && Cancelled == other.Cancelled;
-        }
-
-        public override int GetHashCode()
-        {
-            unchecked
-            {
-                var hashCode = Id.GetHashCode();
-                hashCode = (hashCode * 397) ^ Payment.GetHashCode();
-                hashCode = (hashCode * 397) ^ Cancelled.GetHashCode();
-                return hashCode;
-            }
         }
     }
 }

--- a/PropNotify/lib/Box.cs
+++ b/PropNotify/lib/Box.cs
@@ -1,8 +1,9 @@
-﻿using lib.Common;
+﻿using System;
+using lib.Common;
 
 namespace lib
 {
-    public class Box<T> : Observable<T>
+    public class Box<T> : Observable<T> where T : IEquatable<T>
     {
         public virtual void AddOrUpdate(T ped)
         {

--- a/PropNotify/lib/Common/Observable.cs
+++ b/PropNotify/lib/Common/Observable.cs
@@ -8,7 +8,7 @@ using lib.Interfaces;
 
 namespace lib.Common
 {
-    public class Observable<T> : IPropNotifySubscriber<T>
+    public class Observable<T> : IPropNotifySubscriber<T> where T : IEquatable<T>
     {
         private readonly List<IPropNotify<T>> _observers;
         private readonly List<T> _list;
@@ -27,7 +27,7 @@ namespace lib.Common
                 var props = o.PropsToObserver;
                 if (props != null && props.Any())
                 {
-                    var current = _list.FirstOrDefault(f => f.Equals(obj));
+                    var current = _list.FirstOrDefault(f => !EqualityComparer<T>.Default.Equals(f, obj));
                     if (current == null) return;
                     foreach (var expression in props)
                     {

--- a/PropNotify/lib/Common/PropNotify.cs
+++ b/PropNotify/lib/Common/PropNotify.cs
@@ -4,7 +4,7 @@ using lib.Interfaces;
 
 namespace lib.Common
 {
-    public abstract class PropNotify<T> : IPropNotify<T>
+    public abstract class PropNotify<T> : IPropNotify<T> where T : IEquatable<T>
     {
         public Expression<Func<T, object>>[] PropsToObserver { get; set; }
         public Expression<Func<T, bool>>[] ConditionsToObserver { get; set; }


### PR DESCRIPTION
T Observable must implement IEquatable interface, its gone be used inside Observable.Notify to get current T from list of T addeds.
